### PR TITLE
make ast available

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -15,6 +15,7 @@ declare const xmlQuery: (ast: xmlQuery.XmlNode | xmlQuery.XmlNode[]) => {
     prop: (name: string) => any;
     size: () => number;
     text: () => string;
+    ast: xmlQuery.XmlNode | xmlQuery.XmlNode[];
 };
 declare namespace xmlQuery {
     interface XmlNode {

--- a/dist/index.js
+++ b/dist/index.js
@@ -70,6 +70,7 @@ var xmlQuery = function (ast) {
         prop: prop,
         size: size,
         text: text,
+        ast: ast,
     };
 };
 module.exports = xmlQuery;

--- a/index.ts
+++ b/index.ts
@@ -130,6 +130,7 @@ const xmlQuery = (ast: xmlQuery.XmlNode | xmlQuery.XmlNode[]) => {
         prop,
         size,
         text,
+        ast,
     };
 };
 


### PR DESCRIPTION
Hi, needed this to be able to use [xml-printer](https://github.com/pladaria/xml-printer) after querying something inside the xml.
Like so:
`xmlPrinter(myXmlQuery.find("body").children().ast), { indentation: '    ' });`